### PR TITLE
Issue #1: FIX for yaml loader deprecation warning

### DIFF
--- a/pyflame/__init__.py
+++ b/pyflame/__init__.py
@@ -19,7 +19,7 @@ from pathlib import Path
 class FlameSession:
 
     def __init__(self, config_file):
-        config = yaml.load(open(config_file))
+        config = yaml.load(open(config_file), Loader=yaml.FullLoader)
 
         self.model_xml = config["model_xml"]
         self.model_path = config["model_path"]


### PR DESCRIPTION
Fix for this error:

```
pyflame/__init__.py:22: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  config = yaml.load(open(config_file))
```